### PR TITLE
not surpport gulp.src with option.base param

### DIFF
--- a/lib/gulp-css-spritesmith.js
+++ b/lib/gulp-css-spritesmith.js
@@ -48,7 +48,8 @@ function gulpCssSprite(options) {
             var spriteData = data.spriteData;
             var spriteFile = new gutil.File({
                 contents: new Buffer(spriteData.image, 'binary'),
-                path: spriteData.imagePath
+                path: spriteData.imagePath,
+                base:file.base
             });
             self.push(spriteFile);
 


### PR DESCRIPTION
在gulp.src方法中指定option.base参数后，css输出目录不真确问题
